### PR TITLE
Fixed issue #23 : The datetime_module.mod shouldn't be in there.

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -1,7 +1,10 @@
 # Items needed specifically by autotools
 AM_FCFLAGS = -Wall -O0 -C -fbacktrace
 
-include_HEADERS = datetime_module.mod
+nodist_include_HEADERS = datetime_module.mod
+
+#nodist_HEADERS = datetime_module.mod
+nodist_SOURCES = *.mod
 
 lib_LIBRARIES = libdatetime.a
 


### PR DESCRIPTION
With reference to : https://github.com/milancurcic/datetime-fortran/issues/23 ("Archiving/distributing")

