### PR TITLE
Fixed configuration warning about nodist_SOURCES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ tests/Makefile
 datetime-fortran.pc
 src/tests/datetime_tests
 
+src/tests/test-suite.log
+src/tests/tests-env.sh.log
+src/tests/tests-env.sh.trs
+test-driver
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,5 @@ EXTRA_DIST = CONTRIBUTORS LICENSE README.md \
 dist-hook:
 	./mkdist.sh
 
-AM_TESTS_ENVIRONMENT = . $(srcdir)/test/tests-env.sh
-AM_TESTS_FD_REDIRECT = 9>&2
 
-TESTS = tests-env.sh
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,3 +12,8 @@ EXTRA_DIST = CONTRIBUTORS LICENSE README.md \
 
 dist-hook:
 	./mkdist.sh
+
+AM_TESTS_ENVIRONMENT = . $(srcdir)/test/tests-env.sh
+AM_TESTS_FD_REDIRECT = 9>&2
+
+TESTS = tests-env.sh

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_CONFIG_SRCDIR([src/lib/datetime.f90])
 AM_INIT_AUTOMAKE([foreign]) 
 
 
+
 # for package configuration
 PKG_PROG_PKG_CONFIG
 PKG_INSTALLDIR

--- a/scrub-clean.sh
+++ b/scrub-clean.sh
@@ -17,3 +17,5 @@ rm -rf autom4te.cache
 
 clean_dir src/lib
 clean_dir src/tests
+rm -f src/tests/*log src/tests/*.trs
+test-driver

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -4,7 +4,7 @@ AM_FCFLAGS = -Wall -O0 -C -fbacktrace
 nodist_include_HEADERS = datetime_module.mod
 
 #nodist_HEADERS = datetime_module.mod
-nodist_SOURCES = *.mod
+#nodist_SOURCES = *.mod
 
 lib_LIBRARIES = libdatetime.a
 

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -3,6 +3,7 @@ AM_FCFLAGS = -Wall -O0 -C -fbacktrace
 
 noinst_PROGRAMS = datetime_tests
 
+EXTRA_DIST = tests-env.sh
 
 
 datetime_tests_SOURCES = datetime_tests.f90
@@ -25,3 +26,7 @@ OBJ = datetime_tests.o
 datetime_tests$(EXEEXT): datetime_tests.o
 	$(FC) $(FCFLAGS) $(OBJ) -L$(LIB) -ldatetime -o $@
 
+#bin_SCRIPTS = . tests/tests-env.sh
+AM_TESTS_ENVIRONMENT = . tests-env.sh
+AM_TESTS_FD_REDIRECT = 9>&2
+TESTS = tests-env.sh

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -3,6 +3,8 @@ AM_FCFLAGS = -Wall -O0 -C -fbacktrace
 
 noinst_PROGRAMS = datetime_tests
 
+
+
 datetime_tests_SOURCES = datetime_tests.f90
 
 #datetime_tests$(EXEEXT) : datetime_tests.f90 ../datetime_module.mod

--- a/src/tests/tests-env.sh
+++ b/src/tests/tests-env.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "PASS: foo b"

--- a/src/tests/tests-env.sh
+++ b/src/tests/tests-env.sh
@@ -1,3 +1,22 @@
 #!/usr/bin/env bash
 
-echo "PASS: foo b"
+# remove escape codes
+# Obtained from
+# http://www.commandlinefu.com/commands/view/3584/remove-color-codes-special-characters-with-sed
+noesc () { sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" ; }
+
+LOG=tests-env.sh.log
+datetime_tests | noesc > $LOG
+
+TRS=tests-env.sh.trs
+
+# extract lines that end in PASS or FAIL
+pof () { awk '/PASS$/ {print $0} ; /FAIL$/ {print $0}' ; }
+
+# back to front. Replace the first work by the last
+btf () { awk '{$1=$NF;}1'; }
+
+rmres () { sed 's/: PASS$//' | sed 's/: FAIL$//' ; }
+
+pof <$LOG | btf |  rmres  | awk '{print ":test-result: " $0}' >$TRS
+


### PR DESCRIPTION
Problem was:
src/lib/Makefile.am:7: warning: variable 'nodist_SOURCES' is defined but no program or
src/lib/Makefile.am:7: library has 'nodist' as canonical name (possible typo)

Now fixed.