### PR TITLE
add ./ to tests-env.sh

### DIFF
--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -27,6 +27,6 @@ datetime_tests$(EXEEXT): datetime_tests.o
 	$(FC) $(FCFLAGS) $(OBJ) -L$(LIB) -ldatetime -o $@
 
 #bin_SCRIPTS = . tests/tests-env.sh
-AM_TESTS_ENVIRONMENT = . tests-env.sh
+AM_TESTS_ENVIRONMENT = . ./tests-env.sh
 AM_TESTS_FD_REDIRECT = 9>&2
 TESTS = tests-env.sh


### PR DESCRIPTION
`make check` was broken on machines that don't have `./` in $PATH. This commit fixes that.